### PR TITLE
fix(simulate): Make html required

### DIFF
--- a/pollination/annual_energy_use/entry.py
+++ b/pollination/annual_energy_use/entry.py
@@ -125,7 +125,7 @@ class AnnualEnergyUseEntryPoint(DAG):
     )
 
     html = Outputs.file(
-        source='run/eplustbl.htm', optional=True,
+        source='run/eplustbl.htm',
         description='The result HTML page with summary reports output by the simulation.'
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pollination-honeybee-energy==0.3.15
+pollination-honeybee-energy==0.3.18
 pollination-alias==0.9.12


### PR DESCRIPTION
Technically, they can be bypassed if the user inputs a specific type of IDF but people keep getting failing simulations that look like they succeed so I am making them required again.